### PR TITLE
fix: re2 dependency is required in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "magic-string": "^0.25.7",
     "mocha": "8.1.3",
     "prettier": "2.1.2",
-    "re2": "^1.15.4",
     "rollup": "2.29.0",
     "rollup-plugin-closure-compiler-js": "^1.0.6",
     "rollup-plugin-filesize": "9.0.2",
@@ -78,6 +77,7 @@
   "dependencies": {
     "chalk": "4.1.0",
     "globs": "0.1.4",
+    "re2": "^1.15.4",
     "yargs": "16.0.3"
   },
   "prettier": {


### PR DESCRIPTION
The re2 dependency is currently defined only in the dev dependencies. This PR moves it to the regular dependencies as its required when using rexreplace.