### PR TITLE
Fix replacement-js flag when referencing matched groups when matching multiple files

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -84,11 +84,14 @@ function doReplacement(_file_rr: string, _config_rr: any, _data_rr: string) {
 
 	// Variables to be accessible from js.
 	if (_config_rr.replacementJs) {
-		_config_rr.replacement = dynamicReplacement(_file_rr, _config_rr, _data_rr);
+		_config_rr.replacementDynamic = dynamicReplacement(_file_rr, _config_rr, _data_rr);
 	}
 
 	// Main regexp of the whole thing
-	const result = _data_rr.replace(_config_rr.regex, _config_rr.replacement);
+	const result = _data_rr.replace(
+		_config_rr.regex,
+		_config_rr.replacementJs ? _config_rr.replacementDynamic : _config_rr.replacement
+	);
 
 	// The output of matched strings is done from the replacement, so no need to continue
 	if (_config_rr.outputMatch) {

--- a/test/cli/run.sh
+++ b/test/cli/run.sh
@@ -196,7 +196,12 @@ assert		 		"rexreplace 'foobar' \"['filename:'+filename,'name:'+name,'ext:'+ext,
 reset
 assert		 		"rexreplace 'foo((b)ar)' '€1+€2' my.file -o --replacement-js"    'barb'
 
+## Test replacement-js on multiple files
+reset
+assert		 		"rexreplace 'foo((b)ar)' '€1+€2' *.file -o --replacement-js"    'barb\nabc123'
 
+reset
+assert		 		"rexreplace 'a(.+)' '\"_replace_\"+€1' *.file -o --replacement-js"    'foob_replace_r\n_replace_bc123'
 
 # Content manually testes
 # todo: automate test of content


### PR DESCRIPTION
This PR aims to fix issue #512.

When using dynamic replacement with multiples files being processed, the replacement value was being overridden after the first processed file.
This fix separates the dynamic processing replacement from the standard replacement string as to not lose its value when parsing multiple files with the replacement-js flag.

Two testing scenarios were added to test these instances.